### PR TITLE
Move installation guide to top-level INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,4 +40,4 @@ make test
 ```
 
 ### Play Around
-After the dependencies have installed, users may run the [tutorials](tutorials) and [guides](how_tos) on their local machines.
+After the dependencies have installed, users may run the [tutorials](docs/tutorials) and [guides](docs/how_tos) on their local machines.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <!-- TABLE OF CONTENTS -->
 ### Table of Contents
-* [Installation](docs/installation_guide.md)
+* [Installation](INSTALL.md)
 * [Tutorials](docs/tutorials/)
 * [How-Tos](docs/how_tos/)
 * [Background](docs/background/)


### PR DESCRIPTION
As suggested by a user, it may be beneficial to have the installation guide live in the top-level directory.